### PR TITLE
GitHub Actionsによる自動リリース機能の追加

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,32 @@
+name: Auto Release
+
+on:
+  push:
+    tags:
+      - 'v*' # vで始まるタグがプッシュされたときに実行（例：v0.1.0, v1.0.0）
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # すべての履歴を取得
+
+      # GitHub CLIはUbuntuランナーにプリインストールされているため、別途インストール不要
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # タグ名を取得
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          
+          # gh release create コマンドでリリースを作成
+          gh release create $TAG_NAME \
+            --title "マインスイーパー $TAG_NAME" \
+            --generate-notes


### PR DESCRIPTION
# 実装内容
- タグプッシュ時に自動でリリースノートを生成するGitHub Actions workflow追加
- シンプルな設定でgithub cliを使った自動リリース処理
- マインスイーパーのバージョン履歴を自動的に管理

このPRをマージすると、タグをプッシュするだけで自動的にリリースが生成されるようになります。
例：`git tag -a v0.2.0 -m \"新機能追加\"` → `git push origin v0.2.0`