### PR TITLE
Fix: Update yq GitHub Action to mikefarah/yq

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install yq
-        uses: mikefarah/yq-action@v8
+        uses: mikefarah/yq@master
 
       - name: Read version from version.yaml
         id: version_reader

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install yq
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@v4
 
       - name: Read version from version.yaml
         id: version_reader


### PR DESCRIPTION
Per your feedback, this commit updates the yq action in the `create_tag` workflow to use ~~`mikefarah/yq@master`~~ `mikefarah/yq@v4`. This will use the latest version of yq from the master branch of the specified repository.